### PR TITLE
21 feature 지자체 선택 시 지도 및 대기질 정보 동적 포커스 기능

### DIFF
--- a/src/pages/EneryUsageMonitoring/EchartsExtGmap.tsx
+++ b/src/pages/EneryUsageMonitoring/EchartsExtGmap.tsx
@@ -11,10 +11,11 @@ const EchartsExtGmap = () => {
   // const airQualData = useSelector((state: RootState) => state.airQual.data);
   const gasUsage = useSelector((state: RootState) => state.gasUsage.data);
   const max = useSelector((state: RootState) => state.gasUsage.max);
+  const selected = useSelector((state: RootState) => state.gasUsage.selected);
 
   const chartRef = useRef(null);
   const [googleLoaded, setGoogleLoaded] = useState(false);
-  const [heatmapData, setHeatmapData] = useState<EchartMapData[]>([])
+  // const [heatmapData, setHeatmapData] = useState<EchartMapData[]>([])
   const [scatterData, setScatterData] = useState<EchartMapData[]>([])
   const [top10Data, setTop10Data] = useState<EchartMapData[]>([])
 
@@ -173,6 +174,35 @@ const EchartsExtGmap = () => {
 
     }
   }, [googleLoaded, scatterData, top10Data]);
+
+  useEffect(() => {
+    if (selected && chartRef.current) {
+      // 기존 인스턴스 가져오기
+      const chart = echarts.getInstanceByDom(chartRef.current);
+      if (chart) {
+        // 첫 번째 단계: zoom을 줄여서 잠깐 표시
+        const initialZoomOption = {
+          gmap: {
+            center: selected.coord,
+            zoom: 8,  // 축소된 줌 수준
+          },
+        };
+        chart.setOption(initialZoomOption);
+  
+        // 두 번째 단계: zoom을 11로 되돌려 부드럽게 확대
+        setTimeout(() => {
+          const finalZoomOption = {
+            gmap: {
+              center: selected.coord,
+              zoom: 11,  // 확대된 줌 수준
+            },
+          };
+          chart.setOption(finalZoomOption);
+        }, 500); // 500ms 후 확대 실행
+      }
+    }
+
+  }, [selected])
 
   return (
     <div

--- a/src/pages/EneryUsageMonitoring/EchartsExtGmap.tsx
+++ b/src/pages/EneryUsageMonitoring/EchartsExtGmap.tsx
@@ -3,12 +3,14 @@ import * as echarts from 'echarts';
 import 'echarts-extension-gmap';
 import _, { slice } from 'lodash'
 import { GeoCoord, EchartMapData, GeoCoordVal } from '../../types'
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { AppDispatch, RootState } from '../../state/store';
 import { getGasUsageColor } from '../../utils'
+import { selectGasUsage } from '../../state/gasUsageSlice';
+import { selectLclgvNm } from '../../state/airQualSlice';
 
 const EchartsExtGmap = () => {
-  // const airQualData = useSelector((state: RootState) => state.airQual.data);
+  const dispatch = useDispatch<AppDispatch>();
   const gasUsage = useSelector((state: RootState) => state.gasUsage.data);
   const max = useSelector((state: RootState) => state.gasUsage.max);
   const selected = useSelector((state: RootState) => state.gasUsage.selected);
@@ -67,6 +69,15 @@ const EchartsExtGmap = () => {
 
       // ECharts 인스턴스 생성
       const chart = echarts.init(chartRef.current, 'dark');
+
+
+      // 클릭 이벤트 리스너 추가
+      chart.on('click', (params) => {
+        if (params.seriesType === 'scatter' || params.seriesType === 'effectScatter') {
+          dispatch(selectLclgvNm(params.name))
+          dispatch(selectGasUsage(params.name))
+        }
+      });
 
       // ECharts 옵션 설정
       const option = {

--- a/src/pages/EneryUsageMonitoring/LeftPanel/GasUsageRank.tsx
+++ b/src/pages/EneryUsageMonitoring/LeftPanel/GasUsageRank.tsx
@@ -36,7 +36,7 @@ function GasUsageRank() {
 
   const onClickListItem = (selected: GasUsageByLclgv) => {
     dispatch(selectLclgvNm(selected.lclgvNm))
-    dispatch(selectGasUsage(selected))
+    dispatch(selectGasUsage(selected.lclgvNm))
   }
 
 

--- a/src/state/gasUsageSlice.ts
+++ b/src/state/gasUsageSlice.ts
@@ -1,7 +1,7 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { GasUsageByLclgv } from '../types'
 import { getGas, getElec } from '../services'
-import _, { maxBy, orderBy } from "lodash";
+import _, { find, maxBy, orderBy } from "lodash";
 import { RootState } from './store';
 
 interface GasUsageState {
@@ -19,7 +19,8 @@ const gasUsageSlice = createSlice({
   initialState,
   reducers: {
     selectGasUsage: (state, action) => {
-      state.selected = action.payload;
+      const selected = find(state.data, o => o.lclgvNm === action.payload)
+      state.selected = selected;
     }
   }, 
   extraReducers: (builder) => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -25,7 +25,6 @@ export const getGasUsageColor = (
   max: number, 
   val: number
 ): string => {
-  console.log({max, val})
   if (val <= max * 0.2) return '#0d6efd'; // 상위 20%
   if (val <= max * 0.4) return '#198754'; // 상위 40%
   if (val <= max * 0.6) return '#ffc107'; // 상위 60%


### PR DESCRIPTION
## 📌 작업 개요 (Summary)
- 좌측 패널에서 특정 지자체를 클릭하거나 지도에서 특정 지자체의 마커(Marker)를 클릭할 경우, 좌측 패널에 해당 지자체의 대기질 정보가 자동으로 출력되면서 지도 차트가 해당 지자체의 위치로 자동 이동하며 포커스 처리
  - 지도에서 특정 지자체의 마커(Marker)를 클릭할 경우
     ![좌표이동-지도에서-클릭](https://github.com/user-attachments/assets/7a78749d-a883-41f8-bf7d-c41cd5d71331)

  - 좌측 패널에서 특정 지자체를 클릭한 경우 
    ![좌표이동-좌측-패널에서-선택](https://github.com/user-attachments/assets/0280943e-424a-4276-b0c2-ef108bb13b78)

##  📋 변경 사항 (Changes)
- `GasUsageSlice`의  `selectGasUsage` 함수의 `action.payload` 값을 `GasUsageByLclgv` 객체에서 `lclgvNm: string`으로 수정

##  🔗 연관 이슈 
#21  