### PR TITLE
31 bug 모든 데이터가 로드되기 전에 맵차트를 그려서 깜빡거리는 현상 수정

### DIFF
--- a/src/pages/EneryUsageMonitoring/EchartsExtGmap.tsx
+++ b/src/pages/EneryUsageMonitoring/EchartsExtGmap.tsx
@@ -13,6 +13,8 @@ import ReactDOMServer from 'react-dom/server';
 
 const EchartsExtGmap = () => {
   const dispatch = useDispatch<AppDispatch>();
+  const gasLoading = useSelector((state: RootState) => state.gasUsage.loading);
+  const airLoading = useSelector((state: RootState) => state.airQual.loading);
   const airQualList = useSelector((state: RootState) => state.airQual.data);
   const gasUsageList = useSelector((state: RootState) => state.gasUsage.data);
   const max = useSelector((state: RootState) => state.gasUsage.max);
@@ -55,7 +57,7 @@ const EchartsExtGmap = () => {
   }, [gasUsageList])
 
   useEffect(() => {
-    if (googleLoaded && chartRef.current) {
+    if (!gasLoading && !airLoading && googleLoaded && chartRef.current) {
       // 이미 초기화된 차트 인스턴스가 있는지 확인하고 삭제
       if (echarts.getInstanceByDom(chartRef.current)) {
         echarts.dispose(chartRef.current);
@@ -199,7 +201,15 @@ const EchartsExtGmap = () => {
       chart.setOption(option);
 
     }
-  }, [googleLoaded, scatterData, top10Data, airQualList, gasUsageList]);
+  }, [
+    googleLoaded, 
+    scatterData, 
+    top10Data, 
+    airQualList, 
+    gasUsageList, 
+    gasLoading, 
+    airLoading
+  ]);
 
   useEffect(() => {
     if (selected && chartRef.current) {
@@ -260,10 +270,14 @@ const EchartsExtGmap = () => {
   }, [selected])
 
   return (
-    <div
-      ref={chartRef}
-      style={{ width: '100%', height: '100%' }}
-    />
+    gasLoading || airLoading 
+    ? <div>loading...</div>
+    : (
+      <div
+        ref={chartRef}
+        style={{ width: '100%', height: '100%' }}
+      />
+    )
   );
 };
 

--- a/src/pages/EneryUsageMonitoring/EchartsExtGmap.tsx
+++ b/src/pages/EneryUsageMonitoring/EchartsExtGmap.tsx
@@ -10,6 +10,7 @@ import { selectGasUsage } from '../../state/gasUsageSlice';
 import { selectLclgvNm } from '../../state/airQualSlice';
 import MapTooltip from './MapTooltip';
 import ReactDOMServer from 'react-dom/server';
+import { CircularProgress, Grid } from '@mui/material';
 
 const EchartsExtGmap = () => {
   const dispatch = useDispatch<AppDispatch>();
@@ -271,7 +272,11 @@ const EchartsExtGmap = () => {
 
   return (
     gasLoading || airLoading 
-    ? <div>loading...</div>
+    ? (
+      <Grid container alignItems='center' justifyContent='center' sx={{  height: '100%' }}>
+        <CircularProgress size="6rem"  color="inherit"/>
+      </Grid>
+    )
     : (
       <div
         ref={chartRef}

--- a/src/state/gasUsageSlice.ts
+++ b/src/state/gasUsageSlice.ts
@@ -5,6 +5,7 @@ import _, { find, maxBy, orderBy } from "lodash";
 import { RootState } from './store';
 
 interface GasUsageState {
+  loading: boolean;
   data: GasUsageByLclgv[];
   selected?: GasUsageByLclgv;
   max?: GasUsageByLclgv;
@@ -12,6 +13,7 @@ interface GasUsageState {
 
 const initialState: GasUsageState = {
   data: [],
+  loading: true,
 }
 
 const gasUsageSlice = createSlice({
@@ -28,7 +30,15 @@ const gasUsageSlice = createSlice({
       getGasUsage.fulfilled,
       (state, action) => {
         state.data = orderBy(action.payload, ['gas'], ['desc']);
-        state.max = maxBy(action.payload, 'avgUseQnt')
+        state.max = maxBy(action.payload, 'avgUseQnt');
+        state.loading = false;
+      }
+    )
+    builder.addCase(
+      getGasUsage.rejected,
+      (state) => {
+        console.error('getGasUsage.rejected')
+        state.loading = false;
       }
     )
   }


### PR DESCRIPTION
## 📌 작업 개요 (Summary)
- 가스 사용량과 대기질 데이터가 모두 로드되기 전까지 로딩 화면 출력
  깜빡거림 빈도 수 4회 → 1회로 줄어듦.
  - After
    ![로딩-처리-후](https://github.com/user-attachments/assets/ee3d840a-e272-446e-a46b-b29587f56200)
  - Before
    ![지도맵-로딩-미처리](https://github.com/user-attachments/assets/20519770-02e0-444a-ab3f-a392943cbf83)

##  📋 변경 사항 (Changes)

##  🔗 연관 이슈 
#31 