### PR TITLE
33 bug API 중복 호출 해결

### DIFF
--- a/src/pages/EneryUsageMonitoring/index.tsx
+++ b/src/pages/EneryUsageMonitoring/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import EchartsExtGmap from './EchartsExtGmap'
 import LeftPanel from '../LeftPanel'
 import { useDispatch } from 'react-redux';
@@ -9,24 +9,23 @@ import { getGasUsage } from '../../state/gasUsageSlice';
 
 function EneryUsageMonitoring() {
   const dispatch = useDispatch<AppDispatch>();
-  const [loading, setLoading] = useState<boolean>(true)
-  
-  useEffect(() => {
-    initData();
-  }, [])
+  const isMounted = useRef(false);
 
-  const initData = async () => {
+  useEffect(() => {
+    if (isMounted.current) return;
+    isMounted.current = true;
+    initData();
+  }, []);
+
+  const initData = useCallback(async () => {
     dispatch(getCoordJson());
     dispatch(getAirQualData());
     dispatch(getGasUsage());
-    setLoading(false)
-  }
+  }, [])
 
   return (
     <div style={{ width: '100%', height: '100%'}}>
-      {loading 
-        ? <div>loading ... </div>
-        : <EchartsExtGmap />}
+      <EchartsExtGmap />
     </div>
   );
 }


### PR DESCRIPTION
## 📌 작업 개요 (Summary)
구글링해보니 **React 18** 이후 많은 사람들이 컴포넌트 마운트 시 API가 중복 호출되는 문제를 경험하고 있었다.  
이유를 찾아보니, React 18에서는 `StrictMode`가 활성화되면 컴포넌트를 빠르게 **mount → unmount → 다시 mount**하는 과정을 거친다고 한다.  이 과정에서 `useEffect`가 **두 번 실행**되면서 **API 호출이 중복**되는 상황이 발생한다고 한다.   

React가 **이런 방식을 도입한 이유**는, 컴포넌트가 마운트/언마운트될 때 발생할 수 있는 **잠재적인 문제(예: 애니메이션, 직접적인 DOM 조작 등)를 미리 찾아내기 위해**서라고 한다. 즉, 개발 중에 예기치 않은 부작용을 발견하고 해결할 수 있도록 돕는 것이 목적!

해결방법은 2 가지였다. 
1.  <React.StrictMode> 제거하기 
```
root.render(
  // <React.StrictMode>
    <App />
  // </React.StrictMode>
);
```
2. 마운트 여부를 상태로 저장해서 사용하기 
나는 1번 방법은 **<React.StrictMode>를 제거하면 배포 버전에서는 문제가 발생**할 수 있다는 글을 봐서 **2번 방법을 선택**했다. 
`useEffect`에서 컴포넌트가 실제로 마운트되었는지 여부를 상태로 저장하고, 조건문을 통해 첫 마운트 이후에만 API 호출되도록 하는 방법이다. 나는 불필요한 리렌더링을 방지하기 위해 **`useRef`를 사용하여 마운트 여부를 저장**하였다.  
`useState`를 사용하면 값이 변경될 때마다 컴포넌트가 다시 렌더링되지만, **`useRef`는 값이 변경되어도 리렌더링을 일으키지 않기 때문이다.**
```
const isMounted = useRef(false);

  useEffect(() => {
    if (isMounted.current) return;
    isMounted.current = true;
    initData();
  }, []);

  const initData = useCallback(async () => {
    ...
  }, [])
```


##  📋 변경 사항 (Changes)
* After
<img width="445" alt="image" src="https://github.com/user-attachments/assets/81748b43-85f2-4306-9fea-cfa3315616de">

* Before
<img width="454" alt="스크린샷 2024-11-01 오후 5 39 41" src="https://github.com/user-attachments/assets/c21acb21-1306-4f1f-ae92-544478ee9288">


##  🔗 연관 이슈 
#33  