### PR TITLE
44 bug href -> Link to 변경

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,7 +5,8 @@ import ProfileImage from '../assets/img/profile.jpg';
 import { useDispatch } from 'react-redux';
 import { AppDispatch } from '../state/store';
 import { clickCollapseBtn } from '../state/rightPanelSlice';
-import packageJson from '../../package.json'; // 위치에 따라 경로를 조정하세요
+import packageJson from '../../package.json'; 
+import { Link } from 'react-router-dom'
 
 function Header() {
   const dispatch = useDispatch<AppDispatch>();
@@ -20,14 +21,14 @@ function Header() {
         <Toolbar disableGutters variant="dense" >
           <Grid container justifyContent='space-between' flexWrap='wrap'>
             <Grid item container alignItems='center' flexWrap='nowrap' sx={{  width: 'fit-content' }}>
-              <IconButton href='/' >
+              <IconButton component={Link} to='/'>
                 <TroubleshootIcon fontSize='large' sx={{ mr: 1 }} />
               </IconButton>
               <Typography
                 variant="h6"
                 noWrap
-                component="a"
-                href="/"
+                component={Link}
+                to="/"
                 sx={{
                   display: { xs: 'none', md: 'flex' },
                   fontWeight: 700,


### PR DESCRIPTION
## 📌 작업 개요 (Summary)
- href -> Link to 변경
  - 문제점: 
    `<a href="/">`를 사용하면 브라우저가 **서버에 직접 '해당하는 페이지를 주세요.'라고 요청**을 보낸다. GitHub Pages와 같은 **정적 파일 호스팅 환경**에서는 **서버가 라우팅 정보를 알지 못해** 404 오류가 발생하게 된다. 
  - 해결방법: 
    따라서, React Router에서 제공하는` <Link> `컴포넌트를 사용하면 이 문제를 해결할 수 있다. `<Link>`는 `to` 속성을 통해 **라우팅을 클라이언트 측에서 처리**하므로, basename이 자동으로 적용된 경로로 이동한다. 
  
  
  
##  📋 변경 사항 (Changes)

##  🔗 연관 이슈 
#44 