### PR TITLE
사용하지 않는 폰트 import 제거, 기울임 폰트 제거

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,10 +24,16 @@
       Google Fonts Links:
       Comfortaa, Montserrat
     -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Comfortaa:wght@300..700&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+      rel="preconnect"
+      href="https://fonts.gstatic.com"
+      crossorigin="anonymous"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Comfortaa:wght@300..700"
+      rel="stylesheet"
+    />
 
     <!-- import JavaScript API of Google Map, please replace the key with your own key -->
     <!-- <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyC-9BlLpFiyCeUAv6_7_YADvit_NPw30PI" async defer></script> -->


### PR DESCRIPTION
## 📝 Description
- Google Fonts의 로딩시간 87.44 ms 줄임 
  - 사용하지 않는 글꼴 제거
  - 사용하지 않는 ital(기울임꼴) 설정 제거 
  
## 🚀 Screenshots (Optional)
* 최적화 전
   불필요한 폰트 로딩 
  <img width="650" alt="스크린샷 2025-04-02 오후 8 10 40" src="https://github.com/user-attachments/assets/4cdf2939-1a7c-4ae0-8968-7e4df2469cea" />

* 최적화 후 
  필요한 Comfortaa 폰트만 로드 
  <img width="357" alt="image" src="https://github.com/user-attachments/assets/a86323d0-78be-4c21-ae82-f7c127aff9aa" />
